### PR TITLE
Use `-trimpath` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ PKGDIR := $(BUILDDIR)/pkg
 DISTDIR := $(BUILDDIR)/dist
 
 VERSION := $(shell git describe --tags --abbrev=0)
+GOFLAGS := -trimpath
 LDFLAGS := -X 'main.version=$(VERSION)'
 GOXOSARCH := "darwin/amd64 darwin/arm64 windows/386 windows/amd64 linux/386 linux/amd64"
 GOXOUTPUT := "$(PKGDIR)/$(NAME)_{{.OS}}_{{.Arch}}/{{.Dir}}"
@@ -35,13 +36,13 @@ devel-deps: deps
 .PHONY: build
 ## Build binaries
 build: deps
-	$(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BINDIR)/$(NAME) ./cmd/$(NAME)
+	$(GOBUILD) -trimpath -ldflags "$(LDFLAGS)" -o $(BINDIR)/$(NAME) ./cmd/$(NAME)
 
 .PHONY: cross-build
 ## Cross build binaries
 cross-build:
 	rm -rf $(PKGDIR)
-	gox -osarch=$(GOXOSARCH) -ldflags "$(LDFLAGS)" -output=$(GOXOUTPUT) ./cmd/wareki
+	env GOFLAGS="$(GOFLAGS)" gox -osarch=$(GOXOSARCH) -ldflags "$(LDFLAGS)" -output=$(GOXOUTPUT) ./cmd/wareki
 
 .PHONY: package
 ## Make package


### PR DESCRIPTION
Use `-trimpath` option when `go build`.