### PR TITLE
Introduce golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+issues:
+  exclude-use-default: false
+
+linters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ deps:
 ## Install dependencies for develop
 devel-deps: deps
 	$(GOINSTALL) golang.org/x/tools/cmd/goimports@latest
-	$(GOINSTALL) golang.org/x/lint/golint@latest
+	$(GOINSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	$(GOINSTALL) github.com/Songmu/make2help/cmd/make2help@latest
 	$(GOINSTALL) github.com/mitchellh/gox@latest
 	$(GOINSTALL) github.com/tcnksm/ghr@latest
@@ -71,8 +71,7 @@ test: deps
 .PHONY: lint
 ## Lint
 lint: devel-deps
-	go vet ./...
-	golint -set_exit_status ./...
+	golangci-lint run ./...
 
 .PHONY: fmt
 ## Format source codes

--- a/cmd/wareki/cli.go
+++ b/cmd/wareki/cli.go
@@ -116,15 +116,15 @@ OPTIONS:
 
 func action() func(c *cli.Context) error {
 	return func(c *cli.Context) error {
-		if c.Bool("h") == true {
-			cli.ShowAppHelp(c)
+		if c.Bool("h") {
+			_ = cli.ShowAppHelp(c)
 			return nil
 		}
-		if c.Bool("v") == true {
+		if c.Bool("v") {
 			cli.ShowVersion(c)
 			return nil
 		}
-		if mustWarekiToAC(c) == true {
+		if mustWarekiToAC(c) {
 			warekiToAC(c)
 			return nil
 		}
@@ -186,7 +186,7 @@ func acToWareki(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if match == false {
+	if !match {
 		return errors.New("invalid date format. must specify date: e.g.) 2018 or 2018/01 or 2018/01/01")
 	}
 

--- a/cmd/wareki/cli_test.go
+++ b/cmd/wareki/cli_test.go
@@ -93,9 +93,8 @@ func TestRun_acToWareki(t *testing.T) {
 		}
 
 		actual := outStream.String()
-		expect := fmt.Sprintf("%s", p.expect)
-		if strings.Contains(actual, expect) == false {
-			t.Errorf("Run(%s): Output = %q; want %q", p.argstr, actual, expect)
+		if strings.Contains(actual, p.expect) == false {
+			t.Errorf("Run(%s): Output = %q; want %q", p.argstr, actual, p.expect)
 		}
 	}
 }
@@ -122,9 +121,8 @@ func TestRun_err(t *testing.T) {
 		}
 
 		actual := errStream.String()
-		expect := fmt.Sprintf("%s", p.expect)
-		if strings.Contains(actual, expect) == false {
-			t.Errorf("Run(%s): Output = %q; want %q", p.argstr, actual, expect)
+		if strings.Contains(actual, p.expect) == false {
+			t.Errorf("Run(%s): Output = %q; want %q", p.argstr, actual, p.expect)
 		}
 	}
 }


### PR DESCRIPTION
Introduce golangci-lint instead `go vet` and `golint`.