### PR TITLE
Support standard input

### DIFF
--- a/cmd/wareki/app.go
+++ b/cmd/wareki/app.go
@@ -8,6 +8,6 @@ const appName = "wareki"
 const version = "1.1.1"
 
 func main() {
-	cli := &CLO{outStream: os.Stdout, errStream: os.Stderr}
+	cli := &CLO{inputStream: os.Stdin, outStream: os.Stdout, errStream: os.Stderr}
 	os.Exit(cli.Run(os.Args))
 }

--- a/cmd/wareki/cli.go
+++ b/cmd/wareki/cli.go
@@ -156,23 +156,10 @@ func warekiToAC(c *cli.Context) {
 }
 
 func acToWareki(c *cli.Context) error {
-	f := func(t time.Time, kanji bool) (string, error) {
-		g, err := wareki.Date(t)
-		if err != nil {
-			return "", err
-		}
-
-		year := g.Convert(t)
-		if kanji {
-			return g.KanjiName() + strconv.Itoa(year), nil
-		}
-		return g.ShortName() + strconv.Itoa(year), nil
-	}
-
 	// 西暦から和暦に変換
 	// 引数がないときはシステム日付を和暦に変換
 	if c.NArg() == 0 {
-		str, err := f(time.Now(), c.Bool("K"))
+		str, err := _acToWareki(time.Now(), c.Bool("K"))
 		if err != nil {
 			return err
 		}
@@ -205,10 +192,23 @@ func acToWareki(c *cli.Context) error {
 		return err
 	}
 
-	str, err := f(t, c.Bool("K"))
+	str, err := _acToWareki(t, c.Bool("K"))
 	if err != nil {
 		return err
 	}
 	fmt.Fprintf(clo.outStream, "%s\n", str)
 	return nil
+}
+
+func _acToWareki(t time.Time, kanji bool) (string, error) {
+	g, err := wareki.Date(t)
+	if err != nil {
+		return "", err
+	}
+
+	year := g.Convert(t)
+	if kanji {
+		return g.KanjiName() + strconv.Itoa(year), nil
+	}
+	return g.ShortName() + strconv.Itoa(year), nil
 }

--- a/cmd/wareki/cli_test.go
+++ b/cmd/wareki/cli_test.go
@@ -99,6 +99,24 @@ func TestRun_acToWareki(t *testing.T) {
 	}
 }
 
+func TestRun_acFromStdInputToWareki(t *testing.T) {
+	inputStream := bytes.NewBufferString("1868/01/25\n1989/01/08")
+	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+	clo := &CLO{inputStream: inputStream, outStream: outStream, errStream: errStream}
+
+	args := []string{appName, "-"}
+	status := clo.Run(args)
+	if status != exitCodeOK {
+		t.Errorf("Run(%s): ExitStatus = %d; want %d", args, status, exitCodeOK)
+	}
+
+	expect := "M1\nH1"
+	actual := outStream.String()
+	if strings.Contains(actual, expect) == false {
+		t.Errorf("Run(%s): Output = %q; want %q", args, actual, expect)
+	}
+}
+
 func TestRun_err(t *testing.T) {
 	params := []struct {
 		argstr string


### PR DESCRIPTION
Support standard input.

If AC is "-", read it from standard input.

```sh
$ echo '1868/01/25
1989/01/07
1989/01/08' | wareki -
M1
S64
H1
```