### PR TITLE
urfave/cli を v1 から v3.8.0 へアップグレード

### DIFF
--- a/cmd/wareki/app.go
+++ b/cmd/wareki/app.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 )
 
@@ -9,5 +10,5 @@ const version = "1.2.1"
 
 func main() {
 	cli := &CLO{inputStream: os.Stdin, outStream: os.Stdout, errStream: os.Stderr}
-	os.Exit(cli.Run(os.Args))
+	os.Exit(cli.Run(context.Background(), os.Args))
 }

--- a/cmd/wareki/cli.go
+++ b/cmd/wareki/cli.go
@@ -47,7 +47,7 @@ func (c *CLO) Run(ctx context.Context, args []string) int {
 
 	err := app.Run(ctx, args)
 	if err != nil {
-		fmt.Fprintf(clo.errStream, "%v\n", err)
+		_, _ = fmt.Fprintf(clo.errStream, "%v\n", err)
 		return exitCodeError
 	}
 	return exitCodeOK
@@ -136,8 +136,7 @@ func action() cli.ActionFunc {
 			return nil
 		}
 		if mustWarekiToAD(cmd) {
-			warekiToAD(cmd)
-			return nil
+			return warekiToAD(cmd)
 		}
 		return acToWareki(cmd)
 	}
@@ -151,19 +150,25 @@ func mustWarekiToAD(cmd *cli.Command) bool {
 		cmd.Int("reiwa") != 0
 }
 
-func warekiToAD(cmd *cli.Command) {
+func warekiToAD(cmd *cli.Command) error {
 	switch {
 	case cmd.Int("meiji") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.MEIJI().ToAD(int(cmd.Int("meiji"))))
+		_, err := fmt.Fprintf(clo.outStream, "%d\n", wareki.MEIJI().ToAD(int(cmd.Int("meiji"))))
+		return err
 	case cmd.Int("taisho") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.TAISHO().ToAD(int(cmd.Int("taisho"))))
+		_, err := fmt.Fprintf(clo.outStream, "%d\n", wareki.TAISHO().ToAD(int(cmd.Int("taisho"))))
+		return err
 	case cmd.Int("showa") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.SHOWA().ToAD(int(cmd.Int("showa"))))
+		_, err := fmt.Fprintf(clo.outStream, "%d\n", wareki.SHOWA().ToAD(int(cmd.Int("showa"))))
+		return err
 	case cmd.Int("heisei") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.HEISEI().ToAD(int(cmd.Int("heisei"))))
+		_, err := fmt.Fprintf(clo.outStream, "%d\n", wareki.HEISEI().ToAD(int(cmd.Int("heisei"))))
+		return err
 	case cmd.Int("reiwa") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.REIWA().ToAD(int(cmd.Int("reiwa"))))
+		_, err := fmt.Fprintf(clo.outStream, "%d\n", wareki.REIWA().ToAD(int(cmd.Int("reiwa"))))
+		return err
 	}
+	return nil
 }
 
 func acToWareki(cmd *cli.Command) error {
@@ -174,8 +179,8 @@ func acToWareki(cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(clo.outStream, "%s\n", str)
-		return nil
+		_, err = fmt.Fprintf(clo.outStream, "%s\n", str)
+		return err
 	}
 
 	// 引数があるときは日付にパースして和暦に変換
@@ -237,6 +242,6 @@ func printWareki(cmd *cli.Command, s string) error {
 		return err
 	}
 
-	fmt.Fprintf(clo.outStream, "%s\n", str)
-	return nil
+	_, err = fmt.Fprintf(clo.outStream, "%s\n", str)
+	return err
 }

--- a/cmd/wareki/cli.go
+++ b/cmd/wareki/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,7 +11,7 @@ import (
 	"time"
 
 	"github.com/ebc-2in2crc/wareki"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -27,23 +28,24 @@ type CLO struct {
 var clo *CLO
 
 // Run エントリーポイント
-func (c *CLO) Run(args []string) int {
+func (c *CLO) Run(ctx context.Context, args []string) int {
 	clo = c
 
-	app := cli.NewApp()
-	app.Name = appName
-	app.Usage = "西暦を和暦に変換する"
-	app.Version = version
-	app.HideHelp = true
-	app.HideVersion = true
-	app.Description = description()
-	app.Flags = flags()
-	cli.AppHelpTemplate = appHelpTemplate()
-	app.Action = action()
-	app.Writer = c.outStream
-	app.ErrWriter = c.errStream
+	app := &cli.Command{
+		Name:               appName,
+		Usage:              "西暦を和暦に変換する",
+		Version:            version,
+		HideHelp:           true,
+		HideVersion:        true,
+		Description:        description(),
+		Flags:              flags(),
+		CustomHelpTemplate: appHelpTemplate(),
+		Action:             action(),
+		Writer:             c.outStream,
+		ErrWriter:          c.errStream,
+	}
 
-	err := app.Run(args)
+	err := app.Run(ctx, args)
 	if err != nil {
 		fmt.Fprintf(clo.errStream, "%v\n", err)
 		return exitCodeError
@@ -65,37 +67,45 @@ func description() string {
 
 func flags() []cli.Flag {
 	return []cli.Flag{
-		cli.IntFlag{
-			Name:  "meiji, M",
-			Usage: "明治から西暦に変換します",
+		&cli.IntFlag{
+			Name:    "meiji",
+			Aliases: []string{"M"},
+			Usage:   "明治から西暦に変換します",
 		},
-		cli.IntFlag{
-			Name:  "taisho, T",
-			Usage: "大正から西暦に変換します",
+		&cli.IntFlag{
+			Name:    "taisho",
+			Aliases: []string{"T"},
+			Usage:   "大正から西暦に変換します",
 		},
-		cli.IntFlag{
-			Name:  "showa, S",
-			Usage: "昭和から西暦に変換します",
+		&cli.IntFlag{
+			Name:    "showa",
+			Aliases: []string{"S"},
+			Usage:   "昭和から西暦に変換します",
 		},
-		cli.IntFlag{
-			Name:  "heisei, H",
-			Usage: "平成から西暦に変換します",
+		&cli.IntFlag{
+			Name:    "heisei",
+			Aliases: []string{"H"},
+			Usage:   "平成から西暦に変換します",
 		},
-		cli.IntFlag{
-			Name:  "reiwa, R",
-			Usage: "令和から西暦に変換します",
+		&cli.IntFlag{
+			Name:    "reiwa",
+			Aliases: []string{"R"},
+			Usage:   "令和から西暦に変換します",
 		},
-		cli.BoolFlag{
-			Name:  "kanji, K",
-			Usage: "元号を漢字で出力します",
+		&cli.BoolFlag{
+			Name:    "kanji",
+			Aliases: []string{"K"},
+			Usage:   "元号を漢字で出力します",
 		},
-		cli.BoolFlag{
-			Name:  "help, h",
-			Usage: "このヘルプを表示します",
+		&cli.BoolFlag{
+			Name:    "help",
+			Aliases: []string{"h"},
+			Usage:   "このヘルプを表示します",
 		},
-		cli.BoolFlag{
-			Name:  "version, v",
-			Usage: "バージョンを表示します",
+		&cli.BoolFlag{
+			Name:    "version",
+			Aliases: []string{"v"},
+			Usage:   "バージョンを表示します",
 		},
 	}
 }
@@ -116,52 +126,51 @@ OPTIONS:
 `
 }
 
-func action() func(c *cli.Context) error {
-	return func(c *cli.Context) error {
-		if c.Bool("h") {
-			_ = cli.ShowAppHelp(c)
+func action() cli.ActionFunc {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		if cmd.Bool("help") {
+			return cli.ShowAppHelp(cmd)
+		}
+		if cmd.Bool("version") {
+			cli.ShowVersion(cmd)
 			return nil
 		}
-		if c.Bool("v") {
-			cli.ShowVersion(c)
+		if mustWarekiToAD(cmd) {
+			warekiToAD(cmd)
 			return nil
 		}
-		if mustWarekiToAD(c) {
-			warekiToAD(c)
-			return nil
-		}
-		return acToWareki(c)
+		return acToWareki(cmd)
 	}
 }
 
-func mustWarekiToAD(c *cli.Context) bool {
-	return c.Int("M") != 0 ||
-		c.Int("T") != 0 ||
-		c.Int("S") != 0 ||
-		c.Int("H") != 0 ||
-		c.Int("R") != 0
+func mustWarekiToAD(cmd *cli.Command) bool {
+	return cmd.Int("meiji") != 0 ||
+		cmd.Int("taisho") != 0 ||
+		cmd.Int("showa") != 0 ||
+		cmd.Int("heisei") != 0 ||
+		cmd.Int("reiwa") != 0
 }
 
-func warekiToAD(c *cli.Context) {
+func warekiToAD(cmd *cli.Command) {
 	switch {
-	case c.Int("M") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.MEIJI().ToAD(c.Int("M")))
-	case c.Int("T") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.TAISHO().ToAD(c.Int("T")))
-	case c.Int("S") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.SHOWA().ToAD(c.Int("S")))
-	case c.Int("H") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.HEISEI().ToAD(c.Int("H")))
-	case c.Int("R") != 0:
-		fmt.Fprintf(clo.outStream, "%d\n", wareki.REIWA().ToAD(c.Int("R")))
+	case cmd.Int("meiji") != 0:
+		fmt.Fprintf(clo.outStream, "%d\n", wareki.MEIJI().ToAD(int(cmd.Int("meiji"))))
+	case cmd.Int("taisho") != 0:
+		fmt.Fprintf(clo.outStream, "%d\n", wareki.TAISHO().ToAD(int(cmd.Int("taisho"))))
+	case cmd.Int("showa") != 0:
+		fmt.Fprintf(clo.outStream, "%d\n", wareki.SHOWA().ToAD(int(cmd.Int("showa"))))
+	case cmd.Int("heisei") != 0:
+		fmt.Fprintf(clo.outStream, "%d\n", wareki.HEISEI().ToAD(int(cmd.Int("heisei"))))
+	case cmd.Int("reiwa") != 0:
+		fmt.Fprintf(clo.outStream, "%d\n", wareki.REIWA().ToAD(int(cmd.Int("reiwa"))))
 	}
 }
 
-func acToWareki(c *cli.Context) error {
+func acToWareki(cmd *cli.Command) error {
 	// 西暦から和暦に変換
 	// 引数がないときはシステム日付を和暦に変換
-	if c.NArg() == 0 {
-		str, err := _acToWareki(time.Now(), c.Bool("K"))
+	if cmd.Args().Len() == 0 {
+		str, err := _acToWareki(time.Now(), cmd.Bool("kanji"))
 		if err != nil {
 			return err
 		}
@@ -170,15 +179,15 @@ func acToWareki(c *cli.Context) error {
 	}
 
 	// 引数があるときは日付にパースして和暦に変換
-	s := c.Args()[0]
+	s := cmd.Args().Get(0)
 	if s != "-" {
-		return printWareki(c, s)
+		return printWareki(cmd, s)
 	}
 
 	scanner := bufio.NewScanner(clo.inputStream)
 	for scanner.Scan() {
 		text := scanner.Text()
-		if err := printWareki(c, text); err != nil {
+		if err := printWareki(cmd, text); err != nil {
 			return err
 		}
 	}
@@ -199,7 +208,7 @@ func _acToWareki(t time.Time, kanji bool) (string, error) {
 	return g.ShortName() + strconv.Itoa(year), nil
 }
 
-func printWareki(c *cli.Context, s string) error {
+func printWareki(cmd *cli.Command, s string) error {
 	match, err := regexp.MatchString("^\\d{4}(/\\d{2}(/\\d{2})?)?$", s)
 	if err != nil {
 		return err
@@ -223,7 +232,7 @@ func printWareki(c *cli.Context, s string) error {
 		return err
 	}
 
-	str, err := _acToWareki(t, c.Bool("K"))
+	str, err := _acToWareki(t, cmd.Bool("kanji"))
 	if err != nil {
 		return err
 	}

--- a/cmd/wareki/cli_test.go
+++ b/cmd/wareki/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ func TestRun_versionFlag(t *testing.T) {
 		clo := &CLO{outStream: outStream, errStream: errStream}
 
 		args := strings.Split(p.argstr, " ")
-		status := clo.Run(args)
+		status := clo.Run(context.Background(), args)
 		if status != exitCodeOK {
 			t.Errorf("Run(%s): ExitStatus = %d; want %d", p.argstr, status, exitCodeOK)
 		}
@@ -55,7 +56,7 @@ func TestRun_warekiToADFlag(t *testing.T) {
 		clo := &CLO{outStream: outStream, errStream: errStream}
 
 		args := strings.Split(p.argstr, " ")
-		status := clo.Run(args)
+		status := clo.Run(context.Background(), args)
 		if status != exitCodeOK {
 			t.Errorf("Run(%s): ExitStatus = %d; want %d", p.argstr, status, exitCodeOK)
 		}
@@ -87,7 +88,7 @@ func TestRun_acToWareki(t *testing.T) {
 		clo := &CLO{outStream: outStream, errStream: errStream}
 
 		args := strings.Split(p.argstr, " ")
-		status := clo.Run(args)
+		status := clo.Run(context.Background(), args)
 		if status != exitCodeOK {
 			t.Errorf("Run(%s): ExitStatus = %d; want %d", p.argstr, status, exitCodeOK)
 		}
@@ -105,7 +106,7 @@ func TestRun_acFromStdInputToWareki(t *testing.T) {
 	clo := &CLO{inputStream: inputStream, outStream: outStream, errStream: errStream}
 
 	args := []string{appName, "-"}
-	status := clo.Run(args)
+	status := clo.Run(context.Background(), args)
 	if status != exitCodeOK {
 		t.Errorf("Run(%s): ExitStatus = %d; want %d", args, status, exitCodeOK)
 	}
@@ -133,7 +134,7 @@ func TestRun_err(t *testing.T) {
 		clo := &CLO{outStream: outStream, errStream: errStream}
 
 		args := strings.Split(p.argstr, " ")
-		status := clo.Run(args)
+		status := clo.Run(context.Background(), args)
 		if status != exitCodeError {
 			t.Errorf("Run(%s): ExitStatus = %d; want %d", p.argstr, status, exitCodeError)
 		}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/ebc-2in2crc/wareki
 
 go 1.26
 
-require github.com/urfave/cli v1.20.0
+require github.com/urfave/cli/v3 v3.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,10 @@
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
-github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
+github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 概要

経緯: #24

CLI ライブラリ `urfave/cli` のメジャーアップデート（v1 → v3）を実施し、プロジェクト全体を最新の API 仕様に追従させました。

## 変更点

- **Go 言語・依存関係の更新**
  - `github.com/urfave/cli/v3` を導入し、古い v1 への依存を削除。
- **CLI コア実装の移行 (`cmd/wareki/cli.go`)**
  - v3 の破壊的変更に対応（`cli.NewApp()` から `&cli.Command{}` への移行）。
  - フラグ定義のポインタ化、および `Aliases` フィールドの使用。
  - `Action` 関数のシグネチャ変更に伴う、`context.Context` 経由でのコマンド操作への対応。
- **周辺コードとテストの修正**
  - `app.go`: エントリーポイントでの `Run` 呼び出しに `context.Background()` を追加。
  - `cli_test.go`: v3 の API および Context 仕様に合わせてテストコードを全面的に更新。

### 検証内容

- [x] `go test ./...` による全テストの正常終了を確認。
- [x] 手動での動作確認済み：
  - ヘルプ表示 (`--help`)
  - バージョン表示 (`--version`)
  - 西暦 ⇄ 和暦の相互変換機能
